### PR TITLE
remove unnecessary Promise wrapping

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -30,8 +30,7 @@ async function verifyToken(token) {
 		});
 	}
 
-	return new Promise((resolve, reject) => {
-		jwt.verify(
+	return jwt.verify(
 			token,
 			getKey,
 			{
@@ -40,9 +39,8 @@ async function verifyToken(token) {
 				algorithm: "RS256"
 			},
 			(err, decoded) => {
-				if (err) return reject(err);
-				resolve(decoded);
+				if (err) throw err;
+				return decoded;
 			}
 		);
-	});
 }


### PR DESCRIPTION
Javascript [async notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) automatically wraps return values in a promise. Thrown errors cause the Promise to reject. This code was working, however, because the actual return value of the `verifyToken` method was not being checked. But maybe there would be problems in the future. 

I was able to test failure cases but not success because I didn't have a valid API token.